### PR TITLE
add peek feature

### DIFF
--- a/SysNetCheatGUI/frmMain.Designer.cs
+++ b/SysNetCheatGUI/frmMain.Designer.cs
@@ -68,6 +68,12 @@
             this.label1 = new System.Windows.Forms.Label();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
+            this.labelPeekAddress = new System.Windows.Forms.Label();
+            this.btnPeek = new System.Windows.Forms.Button();
+            this.labelPeekValueType = new System.Windows.Forms.Label();
+            this.txtPeekAddress = new System.Windows.Forms.TextBox();
+            this.peekValueType = new System.Windows.Forms.ComboBox();
+            this.labelPeekStatus = new System.Windows.Forms.Label();
             this.cmsStoredAddress.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -413,11 +419,73 @@
             // 
             this.SaveFileDialog.Filter = "Code File|*.json";
             // 
+            // labelPeekAddress
+            // 
+            this.labelPeekAddress.AutoSize = true;
+            this.labelPeekAddress.Location = new System.Drawing.Point(206, 218);
+            this.labelPeekAddress.Name = "labelPeekAddress";
+            this.labelPeekAddress.Size = new System.Drawing.Size(45, 13);
+            this.labelPeekAddress.TabIndex = 26;
+            this.labelPeekAddress.Text = "Address";
+            // 
+            // btnPeek
+            // 
+            this.btnPeek.Location = new System.Drawing.Point(206, 193);
+            this.btnPeek.Name = "btnPeek";
+            this.btnPeek.Size = new System.Drawing.Size(75, 19);
+            this.btnPeek.TabIndex = 27;
+            this.btnPeek.Text = "Peek";
+            this.btnPeek.UseVisualStyleBackColor = true;
+            this.btnPeek.Click += new System.EventHandler(this.btnPeek_Click);
+            // 
+            // labelPeekValueType
+            // 
+            this.labelPeekValueType.AutoSize = true;
+            this.labelPeekValueType.Location = new System.Drawing.Point(206, 243);
+            this.labelPeekValueType.Name = "labelPeekValueType";
+            this.labelPeekValueType.Size = new System.Drawing.Size(61, 13);
+            this.labelPeekValueType.TabIndex = 28;
+            this.labelPeekValueType.Text = "Value Type";
+            // 
+            // txtPeekAddress
+            // 
+            this.txtPeekAddress.Location = new System.Drawing.Point(266, 215);
+            this.txtPeekAddress.Name = "txtPeekAddress";
+            this.txtPeekAddress.Size = new System.Drawing.Size(192, 20);
+            this.txtPeekAddress.TabIndex = 29;
+            // 
+            // peekValueType
+            // 
+            this.peekValueType.FormattingEnabled = true;
+            this.peekValueType.Items.AddRange(new object[] {
+            "u8",
+            "u16",
+            "u32",
+            "u64"});
+            this.peekValueType.Location = new System.Drawing.Point(266, 240);
+            this.peekValueType.Name = "peekValueType";
+            this.peekValueType.Size = new System.Drawing.Size(192, 21);
+            this.peekValueType.TabIndex = 30;
+            // 
+            // labelPeekStatus
+            // 
+            this.labelPeekStatus.AutoSize = true;
+            this.labelPeekStatus.Location = new System.Drawing.Point(289, 196);
+            this.labelPeekStatus.Name = "labelPeekStatus";
+            this.labelPeekStatus.Size = new System.Drawing.Size(0, 13);
+            this.labelPeekStatus.TabIndex = 31;
+            // 
             // FrmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(470, 546);
+            this.Controls.Add(this.labelPeekStatus);
+            this.Controls.Add(this.peekValueType);
+            this.Controls.Add(this.txtPeekAddress);
+            this.Controls.Add(this.labelPeekValueType);
+            this.Controls.Add(this.btnPeek);
+            this.Controls.Add(this.labelPeekAddress);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.txtDisplayAmount);
             this.Controls.Add(this.lblDisplayAmount);
@@ -496,6 +564,12 @@
         private System.Windows.Forms.OpenFileDialog OpenFileDialog;
         private System.Windows.Forms.SaveFileDialog SaveFileDialog;
         public System.Windows.Forms.ListView lvStoredAddresses;
+        private System.Windows.Forms.Label labelPeekAddress;
+        private System.Windows.Forms.Button btnPeek;
+        private System.Windows.Forms.Label labelPeekValueType;
+        private System.Windows.Forms.TextBox txtPeekAddress;
+        private System.Windows.Forms.ComboBox peekValueType;
+        public System.Windows.Forms.Label labelPeekStatus;
     }
 }
 

--- a/SysNetCheatGUI/frmMain.cs
+++ b/SysNetCheatGUI/frmMain.cs
@@ -146,6 +146,31 @@ namespace SysNetCheatGUI
             }
         }
 
+        private string PeekSize
+        {
+            get
+            {
+                var valueType = "0";
+                switch (peekValueType.SelectedIndex)
+                {
+                    case 0:
+                        valueType = "u8";
+                        break;
+                    case 1:
+                        valueType = "u16";
+                        break;
+                    case 2:
+                        valueType = "u32";
+                        break;
+                    case 3:
+                        valueType = "u64";
+                        break;
+                }
+
+                return valueType;
+            }
+        }
+
         private void btnConnectSwitch_Click(object sender, EventArgs e)
         {
             //if MySwitch does not exist
@@ -299,6 +324,9 @@ namespace SysNetCheatGUI
                 ObjectInvokeEnable(btnRemoveAddress, offOn);
                 ObjectInvokeEnable(cbValueType, offOn);
                 ObjectInvokeEnable(txtDisplayAmount, offOn);
+                ObjectInvokeEnable(btnPeek, offOn);
+                ObjectInvokeEnable(txtPeekAddress, offOn);
+                ObjectInvokeEnable(peekValueType, offOn);
             }
             else
             {
@@ -312,6 +340,9 @@ namespace SysNetCheatGUI
                 btnRemoveAddress.Enabled = offOn;
                 cbValueType.Enabled = offOn;
                 txtDisplayAmount.Enabled = offOn;
+                btnPeek.Enabled = offOn;
+                txtPeekAddress.Enabled = offOn;
+                peekValueType.Enabled = offOn;
             }
         }
 
@@ -721,6 +752,39 @@ namespace SysNetCheatGUI
                     serializer.Formatting = Formatting.Indented;
                     serializer.Serialize(file, _data);
                 }
+            }
+        }
+
+        private void btnPeek_Click(object sender, EventArgs e)
+        {
+            //Set ClickPeek to true
+            MySwitch.ClickedPeek = true;
+            labelPeekStatus.Text = "";
+
+            bool isHex = true;
+            //if GetSearchSize doesn't return Invalid response
+            foreach (char letter in txtPeekAddress.Text) {
+                if (!System.Uri.IsHexDigit(letter))
+                    isHex = false;
+            }
+            if (PeekSize != "0" && isHex && txtPeekAddress.Text != String.Empty)
+                OkayToStartSearch = true;
+            else
+                MessageBox.Show("Search Not Valid!");
+
+            var address = txtPeekAddress.Text.Trim();
+
+            //If txtPeekAddress.Text is not Null/Empty/Blank
+            if (!txtPeekAddress.Text.Trim().Equals(""))
+            {
+                //if both are true
+                if (!MySwitch.SwitchClient.Connected || !OkayToStartSearch) return;
+                //Send MakeCommandString
+                MySwitch.SendCommand(Commands.PeekAddress, "", address, PeekSize, "");
+            }
+            else
+            {
+                MessageBox.Show("AddressValue Must Be Entered!");
             }
         }
     }


### PR DESCRIPTION
Since the main SysNetCheat added the `peek` feature, I figured we should add it to the gui as well.

<img width="265" alt="image" src="https://user-images.githubusercontent.com/5581855/53693172-ff880a00-3d59-11e9-8e01-78ef84810052.png">

I'm very open to changes. We should add a peek feature to the right-click context menu too:
<img width="463" alt="image" src="https://user-images.githubusercontent.com/5581855/53693190-4675ff80-3d5a-11e9-84dc-d89280ba830e.png">
